### PR TITLE
Fixed issues in transfering file in binary mode

### DIFF
--- a/src/Network/FTP/Server.hs
+++ b/src/Network/FTP/Server.hs
@@ -418,7 +418,7 @@ cmd_stor h@(FTPServer _ fs state) args =
                       ASCII -> finally (hLineInteract readh fh datamap)
                                        (hClose readh)
                       Binary -> finally (do vSetBuffering fh (BlockBuffering (Just 4096))
-                                            hCopy readh fh
+                                            rtransmitBinary readh fh
                                         ) (hClose readh)
         in
         if length args < 1


### PR DESCRIPTION
Hi John,
I was to implement some FTP server thing and found ftphs. But I found transferring files in binary mode didn't work in my environment(CentOS 6.4). This is because vGetContents/hGetContents does not work with binary files if the byte sequence could not be decoded into Char. So I tried to fix it and here is the result, please take a look. Thanks.

P.S. I tried to follow the coding style carefully, but I am a Haskell newbie, there might be some non-idiomatic code.

Regards,

Ken
