### PR TITLE
adding function to download large files without running out of memory.

### DIFF
--- a/examples/ftpclient.hs
+++ b/examples/ftpclient.hs
@@ -1,0 +1,18 @@
+import Network.FTP.Client
+
+main :: IO()
+main = do
+  -- connect to SEC's FTP server
+  (ftp_handle, _) <- connectFTP "ftp.sec.gov" 21
+  -- Login as anonymous
+  login ftp_handle "anonymous" (Just "your.email@someserver.org") Nothing
+  -- Set transfer mode to binary
+  sendcmd ftp_handle "TYPE I"
+  -- Change to the directory where the file is located
+  cwd ftp_handle "/edgar/data/1251417/"
+  -- Download the file
+  downloadlargebinary ftp_handle "0001047469-14-010110.txt"
+  -- If we tried using downloadbinary then we might see that the program takes up
+  -- lot of memory and is eventually killed by the haskell runtime
+  -- downloadbinary ftp_handle "0001047469-14-010110.txt"
+  return ()

--- a/ftphs.cabal
+++ b/ftphs.cabal
@@ -44,7 +44,7 @@ Library
    UndecidableInstances, CPP, ScopedTypeVariables
   Build-Depends: network, parsec, base >= 3 && < 5,
                  mtl, regex-compat, 
-               hslogger, MissingH>=1.0.0
+               hslogger, MissingH>=1.0.0, bytestring
   GHC-Options: -O2
 
 Executable runtests


### PR DESCRIPTION
Hi,

1) While using ftphs for building ftp client programs for a personal project, I saw that it was using up a lot of memory when the file being downloaded was large.

2) To solve this issue I added a function that uses Data.ByteString and downloads a file in blocks of 4096 bytes.

3) I also added a example ftp client program.