### PR TITLE
Remove unused dependency

### DIFF
--- a/ftphs.cabal
+++ b/ftphs.cabal
@@ -50,7 +50,7 @@ Library
 Executable runtests
   if flag(buildtests)
     Buildable: True
-    Build-Depends: testpack, HUnit
+    Build-Depends: HUnit
   else
     Buildable: False
   Main-Is: runtests.hs

--- a/testsrc/Network/FTP/Parsertest.hs
+++ b/testsrc/Network/FTP/Parsertest.hs
@@ -19,7 +19,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 module Network.FTP.Parsertest(tests) where
 import Test.HUnit
 import Network.FTP.Client.Parser
-import Test.HUnit.Tools
 import Network.Socket
 
 test_parseReply =


### PR DESCRIPTION
testpack is deprecated and it's not actually used just imported.